### PR TITLE
Fix support for (negative) timestamps before UNIX epoch

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -10,7 +10,7 @@ use super::Timestamped;
 #[derive(Clone, Copy, Debug)]
 pub struct Bar {
    /// A time during the unit of time - usually the time at open.
-   pub timestamp: u64,
+   pub timestamp: i64,
 
    /// The price at the start of the unit of time
    pub open: f64,
@@ -39,7 +39,7 @@ impl PartialEq for Bar {
 }
 impl Timestamped for Bar {
    /// Gets the timestamp in millisecond accuracy
-   fn timestamp_millis(&self) -> u64 { self.timestamp }
+   fn timestamp_millis(&self) -> i64 { self.timestamp }
 }
 
 

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -23,7 +23,7 @@ pub struct Quote {
    pub symbol: String,
 
    /// The timestamp of the quote in millisecond accuracy
-   pub timestamp: u64,
+   pub timestamp: i64,
 
    /// The trading session of the quote - pre market / regular hours / after hours
    pub session: TradingSession,
@@ -36,7 +36,7 @@ pub struct Quote {
 }
 impl Timestamped for Quote {
    /// Gets the timestamp in millisecond accuracy
-   fn timestamp_millis(&self) -> u64 { self.timestamp }
+   fn timestamp_millis(&self) -> i64 { self.timestamp }
 }
 
 
@@ -50,7 +50,7 @@ mod tests {
    #[test]
    fn verify_datetime() {
       let dt = Utc.ymd(1970, 1, 1).and_hms_milli(0, 0, 3, 123);
-      let quote = Quote { symbol: "none".to_string(), timestamp: dt.timestamp_millis() as u64, session: TradingSession::Other, price: 0.1, volume: 0 };
+      let quote = Quote { symbol: "none".to_string(), timestamp: dt.timestamp_millis(), session: TradingSession::Other, price: 0.1, volume: 0 };
       assert_eq!(dt, quote.datetime())
    }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,8 +11,8 @@ pub trait Timestamped {
    }
 
    /// Gets the timestamp as the number milliseconds that have elapsed since the EPOCH
-   fn timestamp_millis(&self) -> u64;
+   fn timestamp_millis(&self) -> i64;
 
    /// Gets the timestamp as the number of seconds that have elapsed since the EPOCH
-   fn timestamp_seconds(&self) -> u64 { self.timestamp_millis() / 1_000 }
+   fn timestamp_seconds(&self) -> i64 { self.timestamp_millis() / 1_000 }
 }


### PR DESCRIPTION
See https://github.com/fbriden/yahoo-finance-rs/issues/18